### PR TITLE
Port more of site-gen to rust

### DIFF
--- a/site-gen/Cargo.lock
+++ b/site-gen/Cargo.lock
@@ -6,6 +6,11 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "dtoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,6 +22,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
@@ -34,17 +44,6 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -86,14 +85,38 @@ dependencies = [
 name = "serde"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "site-gen"
 version = "0.1.0"
 dependencies = [
- "pulldown-cmark 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ramhorns 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -129,20 +152,32 @@ name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "yaml-rust"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "72327b15c228bfe31f1390f93dd5e9279587f0463836393c9df719ce62a3e450"
+"checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum pulldown-cmark 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d1b74cc784b038a9921fd1a48310cc2e238101aa8ae0b94201e2d85121dd68b5"
-"checksum pulldown-cmark 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "77043da1282374688ee212dc44b3f37ff929431de9c9adc3053bd3cee5630357"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum ramhorns 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7525e62204b1d821d987e7cf07ef1a51b237495a1caad61001740008387f261c"
 "checksum ramhorns-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64b3a6039d79d457d97d977da3f72ea190527daac2fdd28b822df0346d666563"
 "checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
+"checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
+"checksum serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "38b08a9a90e5260fe01c6480ec7c811606df6d3a660415808c3c3fa8ed95b582"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"

--- a/site-gen/Cargo.toml
+++ b/site-gen/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Ryan James Spencer <spencer.ryanjames@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-serde = "1.0.98"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"
 ramhorns = "0.5.0"
-pulldown-cmark = "0.5.3"

--- a/site-gen/src/main.rs
+++ b/site-gen/src/main.rs
@@ -2,66 +2,88 @@ extern crate ramhorns;
 extern crate serde;
 
 use ramhorns::{Content, Template};
-//use serde;
+use serde::{Deserialize, Serialize};
 
-#[derive(Content)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct PostHeader {
+    title: String,
+    author: String,
+    date: String,
+    tags: Option<Vec<String>>,
+}
+
+// TODO: Drop clone.
+#[derive(Content, Clone, Debug)]
 struct Post<'a> {
     title: &'a str,
     author: &'a str,
     date: &'a str,
+    #[md]
     content: &'a str,
     url: &'a str,
-    tags: Vec<Tag<'a>>,
+    tags: Vec<Tag>,
 }
 
-#[derive(Content)]
-struct Tag<'a> {
-    url: &'a str,
-    tag: &'a str,
+// TODO: Drop clone.
+#[derive(Content, Clone, Debug)]
+struct Tag {
+    url: String,
+    tag: String,
 }
 
-#[derive(Content)]
+// TODO: Drop clone.
+#[derive(Content, Clone, Debug)]
 struct Blog<'a> {
-    title: &'a str,       // Strings are cool
-    posts: Vec<Post<'a>>, // &'a [Post<'a>] would work too
-    tags: Vec<Tag<'a>>,
+    title: &'a str,
+    posts: Vec<Post<'a>>,
+    tags: Vec<Tag>,
 }
 
 fn main() {
-    let source = std::fs::read_to_string("../site/templates/index.html").unwrap_or_else(|_| {
+    // TODO: Sort posts.
+    // TODO: Pre-render templates upfront?
+    // TODO: Function to strip headers and parse into YAML.
+    let source = std::fs::read_to_string("../site/templates/post.html").unwrap_or_else(|_| {
         eprintln!("could not read template");
         std::process::exit(1);
     });
     let tpl = Template::new(source).unwrap();
-    let rendered = tpl.render(&Blog {
-        title: "justanotherdot",
-        posts: vec![Post {
-            title: "A Fesh Start",
-            author: "there",
-            date: "2019-01-01T00:00:00+00:00",
-            url: "name-of-markdown.html",
-            content: "<p>lorem ipsum</p>",
-            tags: vec![
-                Tag {
-                    url: "/tags/rust",
-                    tag: "rust",
-                },
-                Tag {
-                    url: "/tags/software",
-                    tag: "software",
-                },
-            ],
-        }],
-        tags: vec![
-            Tag {
-                url: "/tags/rust.html",
-                tag: "rust",
-            },
-            Tag {
-                url: "/tags/software.html",
-                tag: "software",
-            },
-        ],
+    let markdown = std::fs::read_to_string("../site/posts/hi.md").unwrap_or_else(|_| {
+        eprintln!("could not read post");
+        std::process::exit(1);
     });
+    let markdown_raw = markdown.split("---").collect::<Vec<&str>>();
+    let markdown = markdown_raw.get(2).unwrap();
+
+    let header_raw = markdown_raw.get(1).unwrap();
+    let header: PostHeader = serde_yaml::from_str(&header_raw).expect("could not parse header");
+
+    let tags = match header.tags {
+        None => vec![],
+        Some(tags) => tags
+            .into_iter()
+            .map(|tag| Tag {
+                url: format!("/tags/{}", tag),
+                tag: tag,
+            })
+            .collect(),
+    };
+
+    let posts = vec![Post {
+        title: &header.title,
+        author: &header.author,
+        date: &header.date,
+        url: "name-of-markdown.html",
+        content: &markdown,
+        tags: tags.clone(),
+    }];
+
+    let _blog = Blog {
+        title: "justanotherdot",
+        posts: posts.clone(),
+        tags: tags.clone(),
+    };
+
+    let rendered = tpl.render(&posts[0]);
     println!("{}", rendered);
 }

--- a/site/templates/post.html
+++ b/site/templates/post.html
@@ -7,28 +7,21 @@
     <title>&#8226; {{title}}</title>
   </head>
   <body>
-
     <section class="section">
       <div class="container">
         <div class="columns">
-
-            <div class="column is-one-quarter">
-              {{>templates/brand.html}}
+          <div class="column is-one-quarter">
+            {{>templates/brand.html}}
+          </div>
+          <div class="column is-half">
+            <h1 class="title is-2">{{title}}</h1>
+            <h2 class="subtitle is-5">on {{date}}</h2>
+            <div class="content is-medium">
+              {{content}}
             </div>
-
-            <div class="column is-half">
-
-              <h1 class="title is-2">{{title}}</h1>
-              <h2 class="subtitle is-5">on {{date}}</h2>
-
-              <div class="content is-medium">
-                {{{content}}}
-              </div>
-
           </div>
         </div>
       </div>
     </section>
-
   </body>
 </html>


### PR DESCRIPTION
This is pretty awesome. Pretty much the only feature that's missing is partials, so doing `{{>template/brand.html}}` but I _could_ render that template and jam it in with triple-braces, or could try to do an upstream PR.